### PR TITLE
fix utm & saveOrder bugs

### DIFF
--- a/catalog/controller/module/retargeting.php
+++ b/catalog/controller/module/retargeting.php
@@ -164,7 +164,7 @@ class ControllerModuleRetargeting extends Controller {
 
             $datetime = new DateTime();
             $start_date = $datetime->format('Y-m-d');
-            $datetime->modify('+6 months');
+            $datetime->modify('+12 months');
             $expiration_date = $datetime->format('Y-m-d');
 
             for ($i = $discount_codes; $i > 0; $i--) {

--- a/catalog/controller/module/retargeting.php
+++ b/catalog/controller/module/retargeting.php
@@ -447,7 +447,7 @@ class ControllerModuleRetargeting extends Controller {
          */
         if ($data['current_page'] === 'product/product') {
 
-            $product_id = $this->request->get['product_id'];
+            $product_id = strtok($this->request->get['product_id'], '?');
             $product_url = $this->url->link('product/product', 'product_id=' . $product_id);
             $product_details = $this->model_catalog_product->getProduct($product_id);
             $product_categories = $this->db->query("SELECT * FROM " . DB_PREFIX . "product_to_category WHERE product_id = '" . (int)$product_id . "'");
@@ -579,7 +579,7 @@ class ControllerModuleRetargeting extends Controller {
          * clickImage
          */
         if ($data['current_page'] === 'product/product') {
-            $clickImage_product_id = $this->request->get['product_id'];
+            $clickImage_product_id = strtok($this->request->get['product_id'], '?');
             $clickImage_product_info = $this->model_catalog_product->getProduct($clickImage_product_id);
             $data['clickImage'] = "
                                                 /* -- clickImage -- */
@@ -636,7 +636,7 @@ class ControllerModuleRetargeting extends Controller {
          * commentOnProduct ✓
          */
         if ($data['current_page'] === 'product/product') {
-            $commentOnProduct_product_info = $this->request->get['product_id'];
+            $commentOnProduct_product_info = strtok($this->request->get['product_id'], '?');
             $data['commentOnProduct'] = "
                                         /* -- commentOnProduct -- */
                                         jQuery(document).ready(function($){
@@ -656,7 +656,7 @@ class ControllerModuleRetargeting extends Controller {
          * addToCart [v1 - class/id listener] ✓
          */
         if ($data['current_page'] === 'product/product') {
-            $mouseOverAddToCart_product_id = $this->request->get['product_id'];
+            $mouseOverAddToCart_product_id = strtok($this->request->get['product_id'], '?');
             $mouseOverAddToCart_product_info = $this->model_catalog_product->getProduct($mouseOverAddToCart_product_id);
             $mouseOverAddToCart_product_promo = isset($mouseOverAddToCart_product_info['promo']) ? : 0;
             $data['mouseOverAddToCart'] = "
@@ -729,14 +729,10 @@ class ControllerModuleRetargeting extends Controller {
         /*
          * saveOrder ✓
          * 
-         * via pre.order.add event
+         * via post.order.add event
          */
         if ($data['current_page'] === 'checkout/success') { 
-          if (
-              (isset($this->session->data['retargeting_pre_order_add']) && !empty($this->session->data['retargeting_pre_order_add']))
-              ||
-              (isset($this->session->data['retargeting_post_order_add']) && !empty($this->session->data['retargeting_post_order_add']))
-                                                                                                                                      ) {
+          if ( (isset($this->session->data['retargeting_post_order_add']) && !empty($this->session->data['retargeting_post_order_add']) ) ) {
               
               $data['order_id'] = $this->session->data['retargeting_post_order_add'];
               $data['order_data'] = $this->model_checkout_order->getOrder($data['order_id']);
@@ -860,7 +856,6 @@ class ControllerModuleRetargeting extends Controller {
                   $response = $orderClient->order->save($orderInfo,$orderProducts);
               }
               
-              unset($this->session->data['retargeting_pre_order_add']);
               unset($this->session->data['retargeting_post_order_add']);
           }
         }


### PR DESCRIPTION
Bug fixes
- Fixed an issue where if the website was not using SEO friendly URLs and if it had ?utm in that URL, everything related to product_id variable would crash the scripts
- Fixed an issue where we sometimes trigger saveOrder in the checkout page
- Changed discount codes availability